### PR TITLE
Fix for cl-lib

### DIFF
--- a/geben.el
+++ b/geben.el
@@ -64,7 +64,8 @@
 (eval-when-compile
   (when (or (not (boundp 'emacs-version))
 	    (string< emacs-version "24"))
-    (error (concat "geben.el: This package requires Emacs 24 or later."))))
+    (error (concat "geben.el: This package requires Emacs 24 or later.")))
+  (require 'cl))
 
 (eval-and-compile
   (require 'cl-lib)


### PR DESCRIPTION
- Use cl-lib functions and macros instead of cl.el
- Load cl.el at compile time for using `lexical-let`.
