### PR TITLE
Add option to control scroll margin

### DIFF
--- a/geben.el
+++ b/geben.el
@@ -3015,6 +3015,11 @@ If non-nil, GEBEN will query the user before removing all breakpoints."
   :group 'geben
   :type 'boolean)
 
+(defcustom geben-scroll-margin nil
+  "Controls the scroll margin of the geben mode."
+  :group 'geben
+  :type '(choice integer (const nil)))
+
 (defvar geben-mode-map nil)
 (unless geben-mode-map
   (setq geben-mode-map (make-sparse-keymap "geben"))
@@ -3099,7 +3104,9 @@ The geben-mode buffer commands:
   (set (make-local-variable 'command-error-function) #'geben-mode-read-only-handler)
   (let ((win (get-buffer-window (current-buffer))))
     (if win
-	(set-window-buffer win (current-buffer)))))
+	(set-window-buffer win (current-buffer))))
+  (when geben-scroll-margin
+    (setq-local scroll-margin geben-scroll-margin)))
 
 (add-hook 'geben-source-visit-hook 'geben-enter-geben-mode)
 


### PR DESCRIPTION
Setting a scroll margin different from 0 allows to see the next lines of code while debugging.

Here's a small screencast to compare a scroll margin of 0 vs 15:
![geben-scroll-margin](https://cloud.githubusercontent.com/assets/8885691/17457182/a8b6d0c8-5bf0-11e6-8347-f01ee5eb7fa4.gif)
